### PR TITLE
Docker build time improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN sed -ri  's/(ENABLE_OS_AUTHENTICATION=).*/\1YES/g' /home/db2inst1/sqllib/ins
 
 RUN mkdir $DB2EXPRESSC_DATADIR && chown db2inst1.db2iadm1 $DB2EXPRESSC_DATADIR
 
-RUN su - db2inst1 -c "db2start && db2set DB2COMM=TCPIP && db2 UPDATE DBM CFG USING DFTDBPATH $DB2EXPRESSC_DATADIR IMMEDIATE" \
+RUN su - db2inst1 -c "db2start && db2set DB2COMM=TCPIP && db2 UPDATE DBM CFG USING DFTDBPATH $DB2EXPRESSC_DATADIR IMMEDIATE && db2 create database db2inst1" \
     && su - db2inst1 -c "db2stop force"
 
 RUN cd /home/db2inst1/sqllib/instance \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,16 +49,15 @@ RUN yum install -y \
     && yum clean all
 
 ENV DB2EXPRESSC_DATADIR /home/db2inst1/data
-ENV DB2EXPRESSC_SHA256 a5c9a3231054047f1f63e7144e4da49c4feaca25d8fce4ad97539d72abfc93d0
 
 # IMPORTANT Note:
 #  Due to compliance for IBM product, you have to host a downloaded DB2 Express-C Zip file yourself
 #  Here are suggested steps:
 #    1) Please download zip file of db2 express-c from http://www-01.ibm.com/software/data/db2/express-c/download.html
-#    2) Then upload it to a cloud storage like AWS S3 or IBM SoftLayer Object Storage 
-#    3) Acquire a URL of file and replace the below
-#    replace URL here 
-ENV DB2EXPRESSC_URL <URL_OF_DB2EXPRESSC_ZIP>
+#    2) Then upload it to a cloud storage like AWS S3 or IBM SoftLayer Object Storage
+#    3) Acquire a URL and SHA-256 hash of file and pass it via Docker's build time argument facility
+ARG DB2EXPRESSC_URL
+ARG DB2EXPRESSC_SHA256
 
 RUN curl -fSLo /tmp/expc.tar.gz $DB2EXPRESSC_URL \
     && echo "$DB2EXPRESSC_SHA256 /tmp/expc.tar.gz" | sha256sum -c - \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 #Supported tags
 
-*  ```latest``` (```10.5.0.5``)
+*  ```latest``` (``10.5.0.5``)
 *  ```10.5.0.5```,
 
 The supported tags stands for ```<db2 version>```.
@@ -71,7 +71,7 @@ $ db2sampl
 ###2) DB2 is deployed in the Docker Engine in:
 
 ```shell
- /opt/ibm/db2/V10.5
+ /home/db2inst1
 ``` 
 
 #License


### PR DESCRIPTION
- Leveraging `build-arg` facility in Docker 1.9
- Fixed README.md
- Creating `db2inst1` database schema during container build
